### PR TITLE
Adjust ConsoleProtocol requirements to allow overriding

### DIFF
--- a/Sources/Console/Console/Console.swift
+++ b/Sources/Console/Console/Console.swift
@@ -45,36 +45,34 @@ public protocol ConsoleProtocol {
     var size: (width: Int, height: Int) { get }
 
     /**
-     Executes a command using the console's POSIX subsystem.
-     The input, output, and error streams will appear
-     as though they are coming from the console program.
+        Executes a command using the console's POSIX subsystem.
+        The input, output, and error streams will appear
+        as though they are coming from the console program.
+     
+        - parameter program: Program to be executed
+        - parameter arguments: Input arguments to the program
 
-     - throws: ConsoleError.execute(Int)
+        - throws: ConsoleError.execute(Int)
      */
     func foregroundExecute(program: String, arguments: [String]) throws
 
     /**
-     Executes a command using the console's POSIX subsystem.
-     The input, output, and error streams will be input
-     and returned as strings.
+        Executes a command using the console's POSIX subsystem.
+        The input, output, and error streams will be input
+        and returned as strings.
 
-     - input: Input argument to method
-     - output: The return string from the method
-     - error: The string in the error enumeration ConsoleError.subexcute
+        - parameter program: Program to be executed
+        - parameter arguments: Input arguments to the program
 
-     - throws: ConsoleError.subexecute(Int, String)
+        - throws: ConsoleError.subexecute(Int, String)
+
+        - returns: The return string from the method
      */
     func backgroundExecute(program: String, arguments: [String]) throws -> String
 }
 
 extension ConsoleProtocol {
-    /**
-        Executes a command using the console's POSIX subsystem.
-        The input, output, and error streams will appear
-        as though they are coming from the console program.
 
-        - throws: ConsoleError.execute(Int)
-    */
     public func foregroundExecute(program: String, arguments: [String]) throws {
         #if os(Linux)
             let stdin = FileHandle.standardInput()
@@ -95,17 +93,6 @@ extension ConsoleProtocol {
         )
     }
 
-    /**
-        Executes a command using the console's POSIX subsystem.
-        The input, output, and error streams will be input
-        and returned as strings.
-
-        - input: Input argument to method
-        - output: The return string from the method
-        - error: The string in the error enumeration ConsoleError.subexcute
-
-        - throws: ConsoleError.subexecute(Int, String)
-    */
     public func backgroundExecute(program: String, arguments: [String]) throws -> String {
         let input = Pipe()
         let output = Pipe()

--- a/Sources/Console/Console/Console.swift
+++ b/Sources/Console/Console/Console.swift
@@ -43,6 +43,28 @@ public protocol ConsoleProtocol {
         The size of the console window used for centering.
     */
     var size: (width: Int, height: Int) { get }
+
+    /**
+     Executes a command using the console's POSIX subsystem.
+     The input, output, and error streams will appear
+     as though they are coming from the console program.
+
+     - throws: ConsoleError.execute(Int)
+     */
+    func foregroundExecute(program: String, arguments: [String]) throws
+
+    /**
+     Executes a command using the console's POSIX subsystem.
+     The input, output, and error streams will be input
+     and returned as strings.
+
+     - input: Input argument to method
+     - output: The return string from the method
+     - error: The string in the error enumeration ConsoleError.subexcute
+
+     - throws: ConsoleError.subexecute(Int, String)
+     */
+    func backgroundExecute(program: String, arguments: [String]) throws -> String
 }
 
 extension ConsoleProtocol {


### PR DESCRIPTION
Added `foregroundExecute(...)` and `backgroundExecute(...)` as protocol requirements with default implementation in an extension.

This allows for overriding mentioned functions in concrete classes, so that Swift chooses the right function dynamically.

For more reference see [this article](https://medium.com/ios-os-x-development/swift-protocol-extension-method-dispatch-6a6bf270ba94#.8i7nreaww).

Also bumped the tag to 0.6.1, since this is a non-breaking release with purely additive changes.