### PR TITLE
Add `backgroundExecuteData` for getting raw `Data` response

### DIFF
--- a/Sources/Console/Console/Console.swift
+++ b/Sources/Console/Console/Console.swift
@@ -93,11 +93,11 @@ extension ConsoleProtocol {
         )
     }
 
-    public func backgroundExecute(program: String, arguments: [String]) throws -> String {
+    public func backgroundExecuteData(program: String, arguments: [String]) throws -> Data {
         let input = Pipe()
         let output = Pipe()
         let error = Pipe()
-
+        
         do {
             try execute(
                 program: program,
@@ -111,9 +111,13 @@ extension ConsoleProtocol {
             let error = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "Unknown"
             throw ConsoleError.backgroundExecute(result, error)
         }
-
+        
         close(output.fileHandleForWriting.fileDescriptor)
-        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return output.fileHandleForReading.readDataToEndOfFile()
+    }
+    
+    public func backgroundExecute(program: String, arguments: [String]) throws -> String {
+        let data = try backgroundExecuteData(program: program, arguments: arguments)
         return String(data: data, encoding: .utf8) ?? ""
     }
 }


### PR DESCRIPTION
This is useful for when the response is raw data. If you want to get the `Data` response with the current `backgroundExecute` implementation, one would have to cast back into a `Data` object from a string, which is pointless.