### PR TITLE
Use all defined environment variables.

### DIFF
--- a/Sources/Console/Terminal/Terminal.swift
+++ b/Sources/Console/Terminal/Terminal.swift
@@ -85,24 +85,8 @@ public class Terminal: ConsoleProtocol {
         let argv: [UnsafeMutablePointer<CChar>?] = args.map{ $0.withCString(strdup) }
         defer { for case let arg? in argv { free(arg) } }
 
-        var environment: [String: String] = [:]
-        #if Xcode
-            let keys = ["SWIFT_EXEC", "HOME", "PATH", "TOOLCHAINS", "DEVELOPER_DIR", "LLVM_PROFILE_FILE"]
-        #else
-            let keys = ["SWIFT_EXEC", "HOME", "PATH", "SDKROOT", "TOOLCHAINS", "DEVELOPER_DIR", "LLVM_PROFILE_FILE"]
-        #endif
-
-        func getenv(_ key: String) -> String? {
-            let out = libc.getenv(key)
-            return out.flatMap { String(validatingUTF8: $0) }
-        }
-
-        for key in keys {
-            if environment[key] == nil {
-                environment[key] = getenv(key)
-            }
-        }
-
+        var environment: [String: String] = ProcessInfo().environment
+        
         let env: [UnsafeMutablePointer<CChar>?] = environment.map{ "\($0.0)=\($0.1)".withCString(strdup) }
         defer { for case let arg? in env { free(arg) } }
 

--- a/Sources/Console/Terminal/Terminal.swift
+++ b/Sources/Console/Terminal/Terminal.swift
@@ -85,8 +85,8 @@ public class Terminal: ConsoleProtocol {
         let argv: [UnsafeMutablePointer<CChar>?] = args.map{ $0.withCString(strdup) }
         defer { for case let arg? in argv { free(arg) } }
 
-        var environment: [String: String] = ProcessInfo().environment
-        
+        var environment: [String: String] = ProcessInfo.processInfo.environment
+
         let env: [UnsafeMutablePointer<CChar>?] = environment.map{ "\($0.0)=\($0.1)".withCString(strdup) }
         defer { for case let arg? in env { free(arg) } }
 


### PR DESCRIPTION
The current version only read a subset of environment variable.

This leads to this issue: https://github.com/vapor/toolbox/issues/109

Using all the defined environment variables solves the issue.

A similar PR has been done on the `swift-package-manager': https://github.com/apple/swift-package-manager/pull/400