### PR TITLE
Added short flag syntax for command options

### DIFF
--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -52,15 +52,16 @@ extension Command {
         
         console.info("Options:")
         for opt in opts {
-            let shortLength = opt.short != nil ? 2 : 0
+            let shortLength = opt.short != nil ? 3 : 0
+            let longFlagDashLength = 2
             console.print(String(
-                repeating: " ", count: width - opt.name.characters.count - shortLength),
+                repeating: " ", count: width - opt.name.characters.count - longFlagDashLength - shortLength),
                 newLine: false
             )
             if let short = opt.short {
-                console.success("\(opt.name) \(short)", newLine: false)
+                console.success("-\(short) --\(opt.name)", newLine: false)
             } else {
-                console.success(opt.name, newLine: false)
+                console.success("--\(opt.name)", newLine: false)
             }
             
             for (i, help) in opt.help.enumerated() {

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -8,7 +8,7 @@ extension Command {
         }
 
         for option in signature.options {
-            console.success("[--\(option.name)] ", newLine: false)
+            console.success("[--\(option.name) -\(option.short)] ", newLine: false)
         }
         print("")
     }

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -52,11 +52,16 @@ extension Command {
         
         console.info("Options:")
         for opt in opts {
+            let shortLength = opt.short != nil ? 2 : 0
             console.print(String(
-                repeating: " ", count: width - opt.name.characters.count),
+                repeating: " ", count: width - opt.name.characters.count - shortLength),
                 newLine: false
             )
-            console.success(opt.name, newLine: false)
+            if let short = opt.short {
+                console.success("\(opt.name) \(short)", newLine: false)
+            } else {
+                console.success(opt.name, newLine: false)
+            }
             
             for (i, help) in opt.help.enumerated() {
                 console.print(" ", newLine: false)

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -15,9 +15,7 @@ extension Command {
     }
 
     public func printSignatureHelp() {
-        let maxWidth = getSignitureLength()
-        let leadingSpace = 2
-        let width = maxWidth + leadingSpace
+        let width = getSignitureLength(withPadding: 2)
         
         let vals = signature.flatMap { $0 as? Value }
         let opts = signature.flatMap { $0 as? Option }
@@ -71,8 +69,8 @@ extension Command {
         }
     }
     
-    fileprivate func getSignitureLength() -> Int {
-        var maxWidth = 2
+    fileprivate func getSignitureLength(withPadding padding: Int) -> Int {
+        var maxWidth = 0
         let shortLength = 3
         for runnable in signature {
             var count = runnable.name.characters.count
@@ -83,6 +81,7 @@ extension Command {
                 maxWidth = count
             }
         }
-        return maxWidth
+        // Add 2 for the dashes before the flag name
+        return maxWidth + 2
     }
 }

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -8,7 +8,8 @@ extension Command {
         }
 
         for option in signature.options {
-            console.success("[--\(option.name) -\(option.short)] ", newLine: false)
+            let short = option.short != nil ? "-\(option.short!)" : ""
+            console.success("[--\(option.name)\(short)] ", newLine: false)
         }
         print("")
     }

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -15,14 +15,7 @@ extension Command {
     }
 
     public func printSignatureHelp() {
-        var maxWidth = 0
-        for runnable in signature {
-            let count = runnable.name.characters.count
-            if count > maxWidth {
-                maxWidth = count
-            }
-        }
-        
+        let maxWidth = getSignitureLength()
         let leadingSpace = 2
         let width = maxWidth + leadingSpace
         
@@ -76,5 +69,20 @@ extension Command {
             }
 
         }
+    }
+    
+    fileprivate func getSignitureLength() -> Int {
+        var maxWidth = 2
+        let shortLength = 3
+        for runnable in signature {
+            var count = runnable.name.characters.count
+            if let _ = runnable as? Option {
+                count += shortLength
+            }
+            if count > maxWidth {
+                maxWidth = count
+            }
+        }
+        return maxWidth
     }
 }

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -82,6 +82,6 @@ extension Command {
             }
         }
         // Add 2 for the dashes before the flag name
-        return maxWidth + 2
+        return maxWidth + padding + 2
     }
 }

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -15,7 +15,7 @@ extension Command {
     }
 
     public func printSignatureHelp() {
-        let width = getSignitureLength(withPadding: 2)
+        let width = getSignatureLength(withPadding: 2)
         
         let vals = signature.flatMap { $0 as? Value }
         let opts = signature.flatMap { $0 as? Option }
@@ -69,7 +69,7 @@ extension Command {
         }
     }
     
-    fileprivate func getSignitureLength(withPadding padding: Int) -> Int {
+    fileprivate func getSignatureLength(withPadding padding: Int) -> Int {
         var maxWidth = 0
         let shortLength = 3
         for runnable in signature {

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -8,7 +8,7 @@ extension Command {
         }
 
         for option in signature.options {
-            let short = option.short != nil ? "-\(option.short!)" : ""
+            let short = option.short != nil ? " -\(option.short!)" : ""
             console.success("[--\(option.name)\(short)] ", newLine: false)
         }
         print("")

--- a/Sources/Console/Command/Option.swift
+++ b/Sources/Console/Command/Option.swift
@@ -1,9 +1,9 @@
 public struct Option: Argument {
     public var name: String
-    public var short: Character
+    public var short: Character?
     public var help: [String]
 
-    public init(name: String, short: Character = Character(""), help: [String] = []) {
+    public init(name: String, short: Character? = nil, help: [String] = []) {
         self.name = name
         self.short = short
         self.help = help

--- a/Sources/Console/Command/Option.swift
+++ b/Sources/Console/Command/Option.swift
@@ -1,9 +1,11 @@
 public struct Option: Argument {
     public var name: String
+    public var short: Character
     public var help: [String]
 
-    public init(name: String, help: [String] = []) {
+    public init(name: String, short: Character = Character(""), help: [String] = []) {
         self.name = name
+        self.short = short
         self.help = help
     }
 }

--- a/Sources/Console/Console/Console+Options.swift
+++ b/Sources/Console/Console/Console+Options.swift
@@ -1,9 +1,10 @@
 extension Sequence where Iterator.Element == String {
     public var options: [String: String] {
+        var iteration = Array(self.enumerated())
         var options: [String: String] = [:]
 
-        for option in filter({ $0.hasPrefix("--") }) {
-            let parts = option.characters.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: false)
+        for option in iteration.filter({ $0.element.hasPrefix("--") }) {
+            let parts = option.element.characters.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: false)
 
             guard parts.count == 3 else {
                 continue
@@ -18,13 +19,32 @@ extension Sequence where Iterator.Element == String {
             } else {
                 options[name] = true.string
             }
+            iteration.remove(at: option.offset)
+        }
+        
+        for option in iteration.filter({ $0.element.hasPrefix("-") }) {
+            let parts = option.element.characters.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+            
+            guard parts.count == 2 else {
+                continue
+            }
+            
+            let token = parts[1].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            
+            let name = String(token[0])
+            
+            if token.count == 1 {
+                options[name] = String(token[0])
+            } else {
+                options[name] = true.string
+            }
         }
         
         return options
     }
 
     public var values: [String] {
-        return filter { !$0.hasPrefix("--") }
+        return filter { !$0.hasPrefix("-") }
     }
 
     public func argument(_ name: String) throws -> String {

--- a/Sources/Console/Console/Console+Options.swift
+++ b/Sources/Console/Console/Console+Options.swift
@@ -1,32 +1,34 @@
+import Foundation
+
 extension Sequence where Iterator.Element == String {
     public var options: [String: String] {
-        var iteration = Array(self.enumerated())
+        let longs = self.filter({ $0.hasPrefix("--") })
+        let shorts = self.filter({ !$0.hasPrefix("--") }).filter({ $0.hasPrefix("-") })
         var options: [String: String] = [:]
-
-        for option in iteration.filter({ $0.element.hasPrefix("--") }) {
-            let parts = option.element.characters.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: false)
-
+        
+        longs.forEach { (element) in
+            let parts = element.characters.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: false)
+            
             guard parts.count == 3 else {
-                continue
+                return
             }
-
+            
             let token = parts[2].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-
+            
             let name = String(token[0])
-
+            
             if token.count == 2 {
                 options[name] = String(token[1])
             } else {
-                options[name] = true.string
+                options[name] = "true"
             }
-            iteration.remove(at: option.offset)
         }
         
-        for option in iteration.filter({ $0.element.hasPrefix("-") }) {
-            let parts = option.element.characters.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        shorts.forEach { (element) in
+            let parts = element.characters.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
             
             guard parts.count == 2 else {
-                continue
+                return
             }
             
             let token = parts[1].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
@@ -34,9 +36,9 @@ extension Sequence where Iterator.Element == String {
             let name = String(token[0])
             
             if token.count == 2 {
-                options[name] = String(token[0])
+                options[name] = String(token[1])
             } else {
-                options[name] = true.string
+                options[name] = "true"
             }
         }
         

--- a/Sources/Console/Console/Console+Options.swift
+++ b/Sources/Console/Console/Console+Options.swift
@@ -33,7 +33,7 @@ extension Sequence where Iterator.Element == String {
             
             let name = String(token[0])
             
-            if token.count == 1 {
+            if token.count == 2 {
                 options[name] = String(token[0])
             } else {
                 options[name] = true.string

--- a/Sources/Console/Console/Console+Run.swift
+++ b/Sources/Console/Console/Console+Run.swift
@@ -74,7 +74,13 @@ extension ConsoleProtocol {
             }
 
             // pass through options
-            for (name, value) in arguments.options {
+            for (var name, value) in arguments.options {
+                if name.count == 1 {
+                    // Get the full flag name from the short version
+                    name = command.signature.flatMap({ $0 as? Option })
+                        .filter({ $0.short == Character(name) })
+                        .first?.name ?? name
+                }
                 passThrough.append("--\(name)=\(value)")
             }
 


### PR DESCRIPTION
This adds an optional property to the `Option` type, so it can be initialized with a short flag syntax, along with the full name:

```swift
Option(name: "foo", short: "f", help: [
    "Nottin' here."
])

Option(name: "another", help: [
    "HELP! HELP!"
 ])
```

When a short flag is added to the option, it is output in the help message:

```
Usage: ./.build/x86_64-apple-macosx10.10/debug/Executable fake [--foo -f] [--bizbaz -b] [--another]


Arugments:

Options:
    foo f Nottin' here.
 bizbaz b Here is some advice
          Don't use this command
  another HELP! HELP!
```

Short flags are also supported in the `Sequence.options` computed property, so they can be accessed the same way as long flags:

```
./.build/x86_64-apple-macosx10.10/debug/Executable fake -f -b=smile --another=one

// arguments.options = ["another": "one", "f": "true", "b": "smile"]
```