### PR TITLE
Fixed value fetching when a command is in a group

### DIFF
--- a/Sources/Console/Console/Console+Run.swift
+++ b/Sources/Console/Console/Console+Run.swift
@@ -20,6 +20,7 @@ extension ConsoleProtocol {
         var commands = group.commands
         var executable = group.id
         var foundCommand: Command? = nil
+        var passThrough = arguments.values.dropFirst()
 
         while foundCommand == nil {
             guard let id = iterator.next() else {
@@ -51,6 +52,9 @@ extension ConsoleProtocol {
                 commands = g.commands
                 executable = "\(executable) \(g.id)"
                 group = g
+                
+                // Remove the first id from the arguments so a command id is not found instead of a value with the `value(_:, arguments)` method.
+                passThrough = passThrough.dropFirst()
             }
         }
 
@@ -65,7 +69,6 @@ extension ConsoleProtocol {
             throw ConsoleError.help
         } else {
             // command should attempt to run
-            var passThrough = arguments.values.dropFirst()
 
             // verify there are enough values to satisfy the signature
             if passThrough.count < command.signature.values.count {


### PR DESCRIPTION
When you add a group of commands to an executable, there are more IDs that need to be passed in to the executable arguments to run the command. Because there are more IDs in the arguments, that would break the `Command.value` method.

```swift
extension Command {
    public func value(_ name: String, from arguments: [String]) throws -> String {
        for (i, value) in signature.values.enumerated() {
            if value.name == name {

                // The index contained in `i` is incorrect
                return arguments[i]
            }
        }

        throw ConsoleError.argumentNotFound
    }
}
```

To fix this issue, when a group of commands is found passed in to the `Console.run` method, we remove the first element in the `arguments` parameter, remove the extra ID:

```swift
if let command = runnable as? Command {
    // got a command
    foundCommand = command
} else if let g = runnable as? Group {
    // got a group of commands
    commands = g.commands
    executable = "\(executable) \(g.id)"
     group = g
                
    // Remove the first id from the arguments so a command id is not found instead of a value with the `value(_:, arguments)` method.
    passThrough = passThrough.dropFirst()
}