### PR TITLE
Removed use of deprecated String.characters property

### DIFF
--- a/Sources/Console/Bar/Bar.swift
+++ b/Sources/Console/Bar/Bar.swift
@@ -79,26 +79,26 @@ public class Bar {
 
     func collapseBar(message: String, style: ConsoleStyle) {
         pthread_mutex_lock(mutex)
-        for i in 0 ..< (width - message.characters.count) {
+        for i in 0 ..< (width - message.count) {
             prepareLine()
 
             console.output(title, style: titleStyle, newLine: false)
 
-            let rate = (width - message.characters.count) / message.characters.count
+            let rate = (width - message.count) / message.count
             let charactersShowing = i / rate
 
 
             var newBar: String = " ["
             for j in 0 ..< charactersShowing {
-                let index = message.characters.index(message.characters.startIndex, offsetBy: j)
-                newBar.append(message.characters[index])
+                let index = message.index(message.startIndex, offsetBy: j)
+                newBar.append(message[index])
             }
             console.output(newBar, style: style, newLine: false)
 
             var oldBar = ""
             for _ in 0 ..< (width - i - 1 - charactersShowing) {
-                let index = bar.characters.index(bar.characters.endIndex, offsetBy: -2)
-                oldBar.append(bar.characters[index])
+                let index = bar.index(bar.endIndex, offsetBy: -2)
+                oldBar.append(bar[index])
             }
             oldBar.append("]")
 
@@ -117,12 +117,12 @@ public class Bar {
         pthread_mutex_lock(mutex)
         prepareLine()
         
-        let total = title.characters.count + 1 + width + status.characters.count + 2 + 3
+        let total = title.count + 1 + width + status.count + 2 + 3
         let trimmedTitle: String
         if console.size.width < total {
             var diff = total - console.size.width
-            if diff > title.characters.count {
-                diff = title.characters.count
+            if diff > title.count {
+                diff = title.count
             }
             diff = diff * -1
             #if swift(>=4)

--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -16,7 +16,7 @@ extension Command {
     public func printSignatureHelp() {
         var maxWidth = 0
         for runnable in signature {
-            let count = runnable.name.characters.count
+            let count = runnable.name.count
             if count > maxWidth {
                 maxWidth = count
             }
@@ -31,7 +31,7 @@ extension Command {
         console.info("Arugments:")
         for val in vals {
             console.print(String(
-                repeating: " ", count: width - val.name.characters.count),
+                repeating: " ", count: width - val.name.count),
                 newLine: false
             )
             console.warning(val.name, newLine: false)
@@ -52,7 +52,7 @@ extension Command {
         console.info("Options:")
         for opt in opts {
             console.print(String(
-                repeating: " ", count: width - opt.name.characters.count),
+                repeating: " ", count: width - opt.name.count),
                 newLine: false
             )
             console.success(opt.name, newLine: false)

--- a/Sources/Console/Console/Console+Options.swift
+++ b/Sources/Console/Console/Console+Options.swift
@@ -3,7 +3,7 @@ extension Sequence where Iterator.Element == String {
         var options: [String: String] = [:]
 
         for option in filter({ $0.hasPrefix("--") }) {
-            let parts = option.characters.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: false)
+            let parts = option.split(separator: "-", maxSplits: 2, omittingEmptySubsequences: false)
 
             guard parts.count == 3 else {
                 continue

--- a/Sources/Console/Console/Console+Print.swift
+++ b/Sources/Console/Console/Console+Print.swift
@@ -10,7 +10,7 @@ extension ConsoleProtocol {
         
         var maxWidth = 0
         for runnable in commands {
-            let count = runnable.id.characters.count
+            let count = runnable.id.count
             if count > maxWidth {
                 maxWidth = count
             }
@@ -21,7 +21,7 @@ extension ConsoleProtocol {
         
         for runnable in commands {
             print(String(
-                repeating: " ", count: width - runnable.id.characters.count),
+                repeating: " ", count: width - runnable.id.count),
                   newLine: false
             )
             warning(runnable.id, newLine: false)

--- a/Sources/Console/Terminal/Terminal.swift
+++ b/Sources/Console/Terminal/Terminal.swift
@@ -38,8 +38,8 @@ public final class Terminal: ConsoleProtocol {
     /// Prints styled output to the terminal.
     public func output(_ string: String, style: ConsoleStyle, newLine: Bool) {
         var lines = 0
-        if string.characters.count > size.width && size.width > 0 {
-            lines = (string.characters.count / size.width) + 1
+        if string.count > size.width && size.width > 0 {
+            lines = (string.count / size.width) + 1
         }
         if newLine {
             lines += 1

--- a/Sources/Console/Utilities/String+Trim.swift
+++ b/Sources/Console/Utilities/String+Trim.swift
@@ -2,10 +2,10 @@ extension String {
     public func trim(characters: [Character] = [" ", "\t", "\n", "\r"]) -> String {
         // while characters
         var mutable = self
-        while let next = mutable.characters.first, characters.contains(next) {
+        while let next = mutable.first, characters.contains(next) {
             mutable.remove(at: mutable.startIndex)
         }
-        while let next = mutable.characters.last, characters.contains(next) {
+        while let next = mutable.last, characters.contains(next) {
             mutable.remove(at: mutable.index(before: mutable.endIndex))
         }
         return mutable


### PR DESCRIPTION
This silences 19 warnings about the use of the deprecated `String.characters` property.

![image](https://user-images.githubusercontent.com/13837190/32558128-adcba1f0-c469-11e7-96a0-18e6396d1db5.png)
