### PR TITLE
Fixed Width Calculation for Help Output

### DIFF
--- a/Sources/Console/Command/Command+Print.swift
+++ b/Sources/Console/Command/Command+Print.swift
@@ -72,16 +72,18 @@ extension Command {
     fileprivate func getSignatureLength(withPadding padding: Int) -> Int {
         var maxWidth = 0
         let shortLength = 3
+        let flagPrefixWidth = 2
         for runnable in signature {
             var count = runnable.name.characters.count
             if let _ = runnable as? Option {
                 count += shortLength
+                count += flagPrefixWidth
             }
             if count > maxWidth {
                 maxWidth = count
             }
         }
         // Add 2 for the dashes before the flag name
-        return maxWidth + padding + 2
+        return maxWidth + padding
     }
 }


### PR DESCRIPTION
Before, the assumption was made that a flag would always have the longest signature in the commands options. This causes extra space before the option names when a value name is the longest.

We now only add the length of the flag prefix the width count if we are calculating the width of a flag signature.