### PR TITLE
add autocomplete output

### DIFF
--- a/Sources/Command/Console+Run.swift
+++ b/Sources/Command/Console+Run.swift
@@ -25,10 +25,10 @@ extension Console {
 
         if let help = try input.parse(option: .flag(name: "help")) {
             assert(help == "true")
-            try outputHelp(
-                for: runnable,
-                executable: input.executablePath.joined(separator: " ")
-            )
+            try outputHelp(for: runnable, executable: input.executablePath.joined(separator: " "))
+        } else if let autocomplete = try input.parse(option: .flag(name: "autocomplete")) {
+            assert(autocomplete == "true")
+            try outputAutocomplete(for: runnable, executable: input.executablePath.joined(separator: " "))
         } else {
             let context = try CommandContext.make(from: &input, console: self, for: runnable)
             try runnable.run(using: context)

--- a/Sources/Command/Output+Autocomplete.swift
+++ b/Sources/Command/Output+Autocomplete.swift
@@ -1,0 +1,14 @@
+import Console
+
+extension OutputConsole {
+    /// Outputs autocomplete for a command.
+    public func outputAutocomplete(for runnable: CommandRunnable, executable: String) throws {
+        var autocomplete: [String] = []
+        switch runnable.type {
+        case .command(let arguments): autocomplete += arguments.map { $0.name }
+        case .group(let commands): autocomplete += commands.keys
+        }
+        autocomplete += runnable.options.map { "--" + $0.name }
+        output(autocomplete.joined(separator: " "), style: .plain)
+    }
+}


### PR DESCRIPTION
Adds an `--autocomplete` flag that returns all available arguments and options. This can be used to generate `bash_completion.d` scripts.