### PR TITLE
Fix logic to parse single `-` prefixed flags

### DIFF
--- a/Sources/Command/CommandInput.swift
+++ b/Sources/Command/CommandInput.swift
@@ -43,13 +43,13 @@ public struct CommandInput {
                     continue
                 }
 
+                // remove this option and update the args
+                _ = arg.remove(at: index)
+                arguments[i] = arg
+
                 if arg.count == 1 {
                     // if just the `-` left, remove this arg
                     arguments[i] = nil
-                } else {
-                    // remove this option and update the args
-                    _ = arg.remove(at: index)
-                    arguments[i] = arg
                 }
             } else {
                 // not an option


### PR DESCRIPTION
This prevents dangling `-` after detecting `-` prefixed flags which results in the following error: `CommandError.excessInput: Too many arguments or unsupported options were supplied` 