### PR TITLE
Dep flag config

### DIFF
--- a/Sources/Command/CommandConfig.swift
+++ b/Sources/Command/CommandConfig.swift
@@ -1,0 +1,79 @@
+import Service
+
+/// Configures commands for a service container.
+///
+///     var commandConfig = CommandConfig.default()
+///     /// You can register command types that will be lazily created
+///     commandConfig.use(FooCommand.self, as: "foo")
+///     /// You can also register pre-initialized instances of a command
+///     commandConfig.use(barCommand, as: "bar")
+///     services.register(commandConfig)
+///
+public struct CommandConfig: Service {
+    /// A lazily initialized `CommandRunnable`.
+    public typealias LazyCommand = (Container) throws -> CommandRunnable
+
+    /// Internal storage
+    private var commands: [String: LazyCommand]
+
+    /// The default runnable
+    private var defaultCommand: LazyCommand?
+
+    /// Create a new `CommandConfig`.
+    public init() {
+        self.commands = [:]
+    }
+
+    /// Adds a `Command` instance to the config.
+    ///
+    ///     var commandConfig = CommandConfig.default()
+    ///     commandConfig.use(barCommand, as: "bar")
+    ///     services.register(commandConfig)
+    ///
+    /// - parameters:
+    ///     - command: Some `CommandRunnable`. This type will be requested from the service container later.
+    ///     - name: A unique name for running this command.
+    ///     - isDefault: If `true`, this command will be set as the default command to run when none other are specified.
+    ///                  Setting this overrides any previous default commands.
+    public mutating func use(_ command: CommandRunnable, as name: String, isDefault: Bool = false) {
+        commands[name] = { _ in command }
+        if isDefault {
+            defaultCommand = { _ in command }
+        }
+    }
+
+    /// Adds a `CommandRunnable` type to the config. This type will be lazily initialized later using a `Container`.
+    ///
+    ///     var commandConfig = CommandConfig.default()
+    ///     commandConfig.use(FooCommand.self, as: "foo")
+    ///     services.register(commandConfig)
+    ///
+    /// - parameters:
+    ///     - command: `Type` of some `Command`. This type will be requested from the service container later.
+    ///     - name: A unique name for running this command.
+    ///     - isDefault: If `true`, this command will be set as the default command to run when none other are specified.
+    ///                  Setting this overrides any previous default commands.
+    public mutating func use<R>(_ command: R.Type, as name: String, isDefault: Bool = false) where R: CommandRunnable {
+        commands[name] = { try $0.make(R.self) }
+        if isDefault {
+            defaultCommand = { try $0.make(R.self) }
+        }
+    }
+
+    /// Resolves the configured commands to a `ConfiguredCommands` struct.
+    ///
+    /// - parameters:
+    ///     - container: `Container` to use for creating lazily initialized commands.
+    /// - returns: `Commands` struct which contains initialized commands.
+    /// - throws: Errors creating the lazy commands from the container.
+    public func resolve(for container: Container) throws -> ConfiguredCommands {
+        let commands = try self.commands.mapValues { lazy -> CommandRunnable in
+            return try lazy(container)
+        }
+
+        return try .init(
+            commands: commands,
+            defaultCommand: defaultCommand.flatMap { try $0(container) }
+        )
+    }
+}

--- a/Sources/Command/ConfiguredCommands.swift
+++ b/Sources/Command/ConfiguredCommands.swift
@@ -1,0 +1,20 @@
+import Service
+
+/// Represents a top-level group of configured commands. This is usually created by calling `resolvle(for:)` on `CommandConfig`.
+public struct ConfiguredCommands: Service {
+    /// Top-level available commands, stored by unique name.
+    public let commands: [String: CommandRunnable]
+
+    /// If set, this is the default top-level command that should run if no other commands are specified.
+    public let defaultCommand: CommandRunnable?
+
+    /// Creates a new `ConfiguredCommands` struct. This is usually done by calling `resolvle(for:)` on `CommandConfig`.
+    ///
+    /// - parameters:
+    ///     - commands: Top-level available commands, stored by unique name.
+    ///     - defaultCommand: If set, this is the default top-level command that should run if no other commands are specified.
+    public init(commands: [String: CommandRunnable] = [:], defaultCommand: CommandRunnable? = nil) {
+        self.commands = commands
+        self.defaultCommand = defaultCommand
+    }
+}

--- a/Sources/Command/Output+Help.swift
+++ b/Sources/Command/Output+Help.swift
@@ -16,7 +16,11 @@ extension OutputConsole {
         }
 
         for opt in runnable.options {
-            success("[--" + opt.name + "] ", newLine: false)
+            if let short = opt.short {
+                success("[--\(opt.name),-\(short)] ", newLine: false)
+            } else {
+                success("[--\(opt.name)] ", newLine: false)
+            }
         }
         print()
         print()

--- a/Sources/Console/Console/Extensions/Console+Confirm.swift
+++ b/Sources/Console/Console/Extensions/Console+Confirm.swift
@@ -1,7 +1,7 @@
 extension OutputConsole where Self: InputConsole {
     /// Requests yes/no confirmation from
     /// the console.
-    public func confirm(_ prompt: String, style: ConsoleStyle = .info) throws -> Bool {
+    public func confirm(_ prompt: String, style: ConsoleStyle = .info) -> Bool {
         var i = 0
         var result = ""
         while result != "y" && result != "yes" && result != "n" && result != "no" {

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -5,15 +5,68 @@ import Service
 import XCTest
 
 class CommandTests: XCTestCase {
-    func testExample() throws {
-        let console = Terminal()
+    func testHelp() throws {
+        let console = TestConsole()
         let group = TestGroup()
         let container = BasicContainer(config: .init(), environment: .testing, services: .init(), on: EmbeddedEventLoop())
         var input = CommandInput(arguments: ["vapor", "sub", "test", "--help"])
         try console.run(group, input: &input, on: container).wait()
+        XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
+        Usage: vapor sub test <foo> [--bar,-b]\u{20}
+
+        This is a test command
+
+        Arguments:
+          foo A foo is required
+              An error will occur if none exists
+
+        Options:
+          bar Add a bar if you so desire
+              Try passing it
+
+        """)
+    }
+
+    func testFlag() throws {
+        let console = TestConsole()
+        let group = TestGroup()
+        let container = BasicContainer(config: .init(), environment: .testing, services: .init(), on: EmbeddedEventLoop())
+        var input = CommandInput(arguments: ["vapor", "sub", "test", "foovalue", "--bar", "baz"])
+        try console.run(group, input: &input, on: container).wait()
+        XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
+        Foo: foovalue Bar: baz
+
+        """)
+    }
+
+    func testShortFlag() throws {
+        let console = TestConsole()
+        let group = TestGroup()
+        let container = BasicContainer(config: .init(), environment: .testing, services: .init(), on: EmbeddedEventLoop())
+        var input = CommandInput(arguments: ["vapor", "sub", "test", "foovalue", "-b", "baz"])
+        try console.run(group, input: &input, on: container).wait()
+        XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
+        Foo: foovalue Bar: baz
+
+        """)
+    }
+
+    func testDeprecatedFlag() throws {
+        let console = TestConsole()
+        let group = TestGroup()
+        let container = BasicContainer(config: .init(), environment: .testing, services: .init(), on: EmbeddedEventLoop())
+        var input = CommandInput(arguments: ["vapor", "sub", "test", "foovalue", "--bar=baz"])
+        try console.run(group, input: &input, on: container).wait()
+        XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
+        Foo: foovalue Bar: baz
+
+        """)
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testHelp", testHelp),
+        ("testFlag", testFlag),
+        ("testShortFlag", testShortFlag),
+        ("testDeprecatedFlag", testDeprecatedFlag),
     ]
 }

--- a/Tests/CommandTests/Utilities.swift
+++ b/Tests/CommandTests/Utilities.swift
@@ -1,6 +1,7 @@
 import Async
 import Console
 import Command
+import Service
 
 extension String: Error {}
 
@@ -56,7 +57,7 @@ final class TestCommand: Command {
     ]
 
     let options: [CommandOption] = [
-        .value(name: "bar", help: ["Add a bar if you so desire", "Try passing it"])
+        .value(name: "bar", short: "b", help: ["Add a bar if you so desire", "Try passing it"])
     ]
 
     let help = ["This is a test command"]
@@ -68,3 +69,38 @@ final class TestCommand: Command {
         return .done(on: context.container)
     }
 }
+
+final class TestConsole: Console {
+    var testInputQueue: [String]
+    var testOutputQueue: [String]
+    var extend: Extend
+
+    init() {
+        self.testInputQueue = []
+        self.testOutputQueue = []
+        self.extend = [:]
+    }
+
+    func input(isSecure: Bool) -> String {
+        return testInputQueue.popLast() ?? ""
+    }
+
+    func output(_ string: String, style: ConsoleStyle, newLine: Bool) {
+        testOutputQueue.insert(string + (newLine ? "\n" : ""), at: 0)
+    }
+
+    func report(error: String, newLine: Bool) {
+        //
+    }
+
+    func clear(_ type: ConsoleClear) {
+        //
+    }
+
+    func execute(program: String, arguments: [String], input: ExecuteStream?, output: ExecuteStream?, error: ExecuteStream?) throws {
+        //
+    }
+
+    var size: (width: Int, height: Int) { return (0, 0) }
+}
+

--- a/Tests/ConsoleTests/ConsoleTests.swift
+++ b/Tests/ConsoleTests/ConsoleTests.swift
@@ -24,7 +24,7 @@ class ConsoleTests: XCTestCase {
 
         console.input = name
 
-        let response = try console.confirm(question)
+        let response = console.confirm(question)
 
         XCTAssertEqual(response, true)
         XCTAssertEqual(console.output, question + "\ny/n> ")


### PR DESCRIPTION
- [x] adds deprecated support for `--option=value` flag style.
- [x] adds `CommandConfig` and `ConfiguredCommands` structs
- [x] makes `console.confirm` non-throwing
- [x] fixes #62 