### PR TITLE
Added Optional Arguments to Command

### DIFF
--- a/Sources/Command/Command/CommandArgument.swift
+++ b/Sources/Command/Command/CommandArgument.swift
@@ -31,19 +31,33 @@ public struct CommandArgument {
     /// - parameters:
     ///     - name: This argument's unique name. Use this to fetch the argument from the `CommandContext`.
     public static func argument(name: String, help: [String] = []) -> CommandArgument {
-        return .init(name: name, help: help)
+        return .init(name: name, optional: false, help: help)
     }
 
+    /// Creates a new `CommandArgument`. The command does not fail if this argument is not passed in.
+    ///
+    ///      let arguments: [CommandArgument] = [.optional(name: "message")]
+    ///
+    /// - parameters:
+    ///     - name: This argument's unique name. Use this to fetch the argument from the `CommandContext`.
+    public static func optional(name: String, help: [String] = []) -> CommandArgument {
+        return .init(name: name, optional: true, help: help)
+    }
+    
     /// The argument's unique name.
     public let name: String
 
     /// The arguments's help text when `--help` is passed.
     public let help: [String]
 
+    /// Whether the command should automatically fail if the argument is passed in or not.
+    public let optional: Bool
+    
     /// Creates a new command argument
     /// Create via static methods.
-    internal init(name: String, help: [String]) {
+    internal init(name: String, optional: Bool, help: [String]) {
         self.name = name
         self.help = help
+        self.optional = optional
     }
 }

--- a/Sources/Command/Run/CommandContext.swift
+++ b/Sources/Command/Run/CommandContext.swift
@@ -80,14 +80,18 @@ public struct CommandContext {
         }
 
         for arg in arguments {
-            guard let value = try input.parse(argument: arg) else {
-                throw CommandError(
-                    identifier: "argumentRequired",
-                    reason: "Argument `\(arg.name)` is required.",
-                    source: .capture()
-                )
+            if arg.optional {
+                parsedArguments[arg.name] = try input.parse(argument: arg)
+            } else {
+                guard let value = try input.parse(argument: arg) else {
+                    throw CommandError(
+                        identifier: "argumentRequired",
+                        reason: "Argument `\(arg.name)` is required.",
+                        source: .capture()
+                    )
+                }
+                parsedArguments[arg.name] = value
             }
-            parsedArguments[arg.name] = value
         }
 
 

--- a/Sources/Command/Run/Output+Help.swift
+++ b/Sources/Command/Run/Output+Help.swift
@@ -7,7 +7,11 @@ extension Console {
         switch runnable.type {
         case .command(let arguments):
             for arg in arguments {
-                output(("<" + arg.name + "> ").consoleText(.warning), newLine: false)
+                if arg.optional {
+                    output(("[<" + arg.name + ">] ").consoleText(.warning), newLine: false)
+                } else {
+                    output(("<" + arg.name + "> ").consoleText(.warning), newLine: false)
+                }
             }
         case .group:
             output("<command> ".consoleText(.warning), newLine: false)

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -12,13 +12,15 @@ class CommandTests: XCTestCase {
         var input = CommandInput(arguments: ["vapor", "sub", "test", "--help"])
         try console.run(group, input: &input, on: container).wait()
         XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
-        Usage: vapor sub test <foo> [--bar,-b]\u{20}
+        Usage: vapor sub test <foo> [<baz>] [--bar,-b]\u{20}
 
         This is a test command
 
         Arguments:
           foo A foo is required
               An error will occur if none exists
+          baz A baz is optional
+              No error will occur if it is not passed in
 
         Options:
           bar Add a bar if you so desire
@@ -63,10 +65,23 @@ class CommandTests: XCTestCase {
         """)
     }
 
+    func testOptionlArg()throws {
+        let console = TestConsole()
+        let group = TestGroup()
+        let container = BasicContainer(config: .init(), environment: .testing, services: .init(), on: EmbeddedEventLoop())
+        var input = CommandInput(arguments: ["vapor", "sub", "test", "foovalue", "bazvalue", "--bar=baz"])
+        try console.run(group, input: &input, on: container).wait()
+        XCTAssertEqual(console.testOutputQueue.reversed().joined(separator: ""), """
+        Baz: bazvalue Foo: foovalue Bar: baz
+
+        """)
+    }
+    
     static var allTests = [
         ("testHelp", testHelp),
         ("testFlag", testFlag),
         ("testShortFlag", testShortFlag),
         ("testDeprecatedFlag", testDeprecatedFlag),
+        ("testOptionlArg", testOptionlArg)
     ]
 }

--- a/Tests/CommandTests/Utilities.swift
+++ b/Tests/CommandTests/Utilities.swift
@@ -53,6 +53,10 @@ final class TestCommand: Command {
         .argument(
             name: "foo",
             help: ["A foo is required", "An error will occur if none exists"]
+        ),
+        .optional(
+            name: "baz",
+            help: ["A baz is optional", "No error will occur if it is not passed in"]
         )
     ]
 
@@ -63,9 +67,17 @@ final class TestCommand: Command {
     let help = ["This is a test command"]
 
     func run(using context: CommandContext) throws -> Future<Void> {
+        let bazText: String
+        
         let foo = try context.argument("foo")
         let bar = try context.requireOption("bar")
-        context.console.output("Foo: \(foo) Bar: \(bar)".consoleText(.info))
+        if let baz = context.arguments["baz"] {
+            bazText = "Baz: \(baz) "
+        } else {
+            bazText = ""
+        }
+        
+        context.console.output((bazText + "Foo: \(foo) Bar: \(bar)").consoleText(.info), newLine: true)
         return .done(on: context.container)
     }
 }


### PR DESCRIPTION
This PR adds an `optional` property to the `CommandArgument` struct:

```swift
CommandArgument.optional(name: "foo", help: ["Argument not required"])
```

When a command's arguments are parsed from the input, no error will be thrown if the argument is not found. You can optionally access the argument using the `context.arguments` dictionary property:

```swift
if let foo = context.arguments["foo"] {
    // Code here...
}
```