### PR TITLE
only output help for command errors

### DIFF
--- a/Sources/Command/Run/Console+Run.swift
+++ b/Sources/Command/Run/Console+Run.swift
@@ -16,7 +16,9 @@ extension Console {
         do {
             return try _run(runnable, input: &input, on: container)
         } catch {
-            outputHelp(for: runnable, executable: input.executablePath.joined(separator: " "))
+            if error is CommandError {
+                outputHelp(for: runnable, executable: input.executablePath.joined(separator: " "))
+            }
             return Future.map(on: container) {
                 throw error
             }


### PR DESCRIPTION
It's getting pretty bogged down in the help command when it outputs for every error. Having just CommandError logs when uses command incorrectly, but not when command fails. That way the failure output can direct them more clearly