### PR TITLE
Make `LogLevel.style` public

### DIFF
--- a/Sources/Console/Utilities/ConsoleLogger.swift
+++ b/Sources/Console/Utilities/ConsoleLogger.swift
@@ -24,7 +24,7 @@ public final class ConsoleLogger: Logger {
 
 extension LogLevel {
     /// Converts log level to console style
-    fileprivate var style: ConsoleStyle {
+    public var style: ConsoleStyle {
         switch self {
         case .custom, .verbose, .debug: return .plain
         case .error, .fatal: return .error


### PR DESCRIPTION
I think it's quite useful to have access to `LogLevel.style` outside of this file as well, thus this PR. If there is a reason for this being private, please let me know, I'll close the PR again 😄 