### PR TITLE
Added CommandProtocol which allows typesafe definition of a Command using enums

### DIFF
--- a/Sources/Command/CommandProtocol/CommandArguments.swift
+++ b/Sources/Command/CommandProtocol/CommandArguments.swift
@@ -1,0 +1,32 @@
+//
+//  CommandArguments.swift
+//  Async
+//
+//  Created by Luke Street on 12/30/18.
+//
+
+/// Describes type that may be used as a `Command's` arguments - best modeled as an enum
+public protocol CommandArguments: CaseIterable {
+    var name: String { get }
+    var help: [String] { get }
+}
+
+extension CommandArguments {
+    public var name: String { return self.caseName }
+    public var help: [String] { return [] }
+}
+
+extension CommandArguments {
+    /// Exposes all arguments defined by conforming type
+    public static var arguments: [CommandArgument] {
+        return zip(
+            Self
+                .allCases
+                .map(get(\.caseName)),
+            Self
+                .allCases
+                .map(get(\.help))
+            )
+            .map(CommandArgument.argument)
+    }
+}

--- a/Sources/Command/CommandProtocol/CommandContext+Extensions.swift
+++ b/Sources/Command/CommandProtocol/CommandContext+Extensions.swift
@@ -1,0 +1,50 @@
+//
+//  CommandContext+Extensions.swift
+//  Async
+//
+//  Created by Luke Street on 12/30/18.
+//
+
+// Convenience functions used for type safe accessing of a `Command's` arguments, options, and flags
+extension CommandContext {
+    
+    /// Uses case of `CommandOptions` as a key to retrieve an option if it has been provided
+    ///
+    /// - Parameter key: CommandOptions case corresponding to desired option
+    /// - Returns: The corresponding option if it has been provided by the user
+    public func option<Key: CommandOptions>(_ key: Key) -> String? {
+        return option(key.caseName)
+    }
+    
+    /// Uses case of `CommandFlags` as a key to retrieve whether the flag has been provided
+    ///
+    /// - Parameter key: CommandFlags case corresponding to desired flag
+    /// - Returns: `true` if flag has been provided, `false` if not
+    public func flag<Key: CommandFlags>(_ key: Key) -> Bool {
+        return flag(key.caseName)
+    }
+    
+    /// Uses case of `CommandArguments` as a key to retrieve an argument
+    ///
+    /// - Parameter key: CommandArguments case corresponding to desired argument
+    /// - Returns: The corresponding argument
+    public func argument<Key: CommandArguments>(_ key: Key) throws -> String {
+        return try argument(key.caseName)
+    }
+    
+    /// Uses string key to retrieve an option if it has been provided
+    ///
+    /// - Parameter key: String corresponding to desired option
+    /// - Returns: The corresponding option if it has been provided by the user
+    internal func option(_ key: String) -> String? {
+        return options[key]
+    }
+    
+    /// String as a key to retrieve whether the flag has been provided
+    ///
+    /// - Parameter key: String corresponding to desired flag
+    /// - Returns: `true` if flag has been provided, `false` if not
+    internal func flag(_ key: String) -> Bool {
+        return options[key] != nil
+    }
+}

--- a/Sources/Command/CommandProtocol/CommandFlags.swift
+++ b/Sources/Command/CommandProtocol/CommandFlags.swift
@@ -1,0 +1,34 @@
+//
+//  CommandFlags.swift
+//  Async
+//
+//  Created by Luke Street on 12/30/18.
+//
+
+/// Describes type that may be used as a `Command's` options - best modeled as an enum
+public protocol CommandFlags: CaseIterable {
+    
+    var name: String { get }
+    
+    var short: Character? { get }
+    
+    var help: [String] { get }
+}
+
+/// Default implementations for name, short, and help
+extension CommandFlags {
+    public var name: String { return self.caseName }
+    public var short: Character? { return self.caseName.first }
+    public var help: [String] { return [] }
+}
+
+extension CommandFlags {
+    /// Exposes all flags defined by conforming type
+    public static var flags: [CommandOption] {
+        return zip(
+            Self.allCases.map(get(\Self.caseName)),
+            Self.allCases.map(get(\Self.caseName.first)),
+            Self.allCases.map(get(\.help))
+        ).map(CommandOption.flag)
+    }
+}

--- a/Sources/Command/CommandProtocol/CommandOptions.swift
+++ b/Sources/Command/CommandProtocol/CommandOptions.swift
@@ -1,0 +1,40 @@
+//
+//  CommandOptions.swift
+//  Async
+//
+//  Created by Luke Street on 12/30/18.
+//
+
+/// Describes type that may be used as a `Command's` options - best modeled as an enum
+public protocol CommandOptions: CaseIterable {
+    
+    var name: String { get }
+    
+    var short: Character? { get }
+    
+    var defaultValue: String? { get }
+    
+    var help: [String] { get }
+    
+}
+
+/// Default implementations for name, short, defaultValue, and help
+extension CommandOptions {
+    public var name: String { return self.caseName }
+    public var short: Character? { return self.caseName.first }
+    public var defaultValue: String? { return nil }
+    public var help: [String] { return [] }
+}
+
+extension CommandOptions {
+    
+    /// Exposes all options defined by conforming type
+    public static var options: [CommandOption] {
+        return zip(
+            Self.allCases.map(get(\.caseName)),
+            Self.allCases.map(get(\Self.caseName.first)),
+            Self.allCases.map(get(\.defaultValue)),
+            Self.allCases.map(get(\.help))
+        ).map(CommandOption.value)
+    }
+}

--- a/Sources/Command/CommandProtocol/CommandProtocol.swift
+++ b/Sources/Command/CommandProtocol/CommandProtocol.swift
@@ -1,0 +1,64 @@
+//
+//  CommandProtocol.swift
+//  Async
+//
+//  Created by Luke Street on 12/30/18.
+//
+
+
+/// Allows a Command to define its options, arguments, and flags by simply supplying the desired types
+///
+/// Example:
+///     struct CowsayCommand: CommandProtocol {
+///
+///         enum Arguments: CommandArguments {
+///             case message
+///         }
+///
+///         enum Options: CommandOptions {
+///             case eyes, tongue
+///         }
+///
+///         enum Flags: CommandFlags {}
+///
+///         var help: [String] {
+///             return ["Generates ASCII picture of a cow with a message."]
+///         }
+///
+///         func run(using context: CommandContext) throws -> Future<Void> {
+///             let message = try context.argument(Argument.message)
+///             let eyes = context.options(Optins.eyes) ?? "oo"
+///             let tongue = context.options(Options.tongue) ?? " "
+///             let padding = String(repeating: "-", count: message.count)
+///             let text: String = """
+///               \(padding)
+///             < \(message) >
+///               \(padding)
+///                       \\   ^__^
+///                        \\  (\(eyes)\\_______
+///                           (__)\\       )\\/\\
+///                             \(tongue)  ||----w |
+///                                ||     ||
+///             """
+///             context.console.print(text)
+///             return .done(on: context.container)
+///         }
+///     }
+public protocol CommandProtocol: Command {
+    associatedtype Options: CommandOptions
+    associatedtype Arguments: CommandArguments
+    associatedtype Flags: CommandFlags
+}
+
+extension CommandProtocol {
+    
+    /// Satisfy `arguments` requirement using associated `CommandArguments` type
+    public var arguments: [CommandArgument] {
+        return Arguments.arguments
+    }
+    
+    /// Satisfy `options` requirement using associated `CommandOptions` and `CommandFlags` type
+    public var options: [CommandOption] {
+        return Options.options + Flags.flags
+    }
+}

--- a/Sources/Command/Utilities/CaseIterable+Extension.swift
+++ b/Sources/Command/Utilities/CaseIterable+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  CaseIterable+Extension.swift
+//  Async
+//
+//  Created by Luke Street on 1/12/19.
+//
+
+import Foundation
+
+extension CaseIterable {
+    public var caseName: String { return String(describing: self) }
+}

--- a/Sources/Command/Utilities/KeyPath.swift
+++ b/Sources/Command/Utilities/KeyPath.swift
@@ -1,0 +1,19 @@
+//
+//  KeyPath.swift
+//  Async
+//
+//  Created by Luke Street on 1/12/19.
+//
+
+
+/// Produces a getter function for a given key path. Useful for composing property access with functions.
+///
+///     get(\String.count)
+///     // (String) -> Int
+///
+/// - Parameter keyPath: A key path.
+/// - Returns: A getter function.
+/// - Note: First defined here: https://github.com/pointfreeco/swift-overture/blob/master/Sources/Overture/KeyPath.swift
+public func get<Root, Value>(_ keyPath: KeyPath<Root, Value>) -> (Root) -> Value {
+    return { root in root[keyPath: keyPath] }
+}

--- a/Sources/Command/Utilities/ZipArray.swift
+++ b/Sources/Command/Utilities/ZipArray.swift
@@ -1,0 +1,18 @@
+//
+//  ZipSequence.swift
+//  Async
+//
+//  Created by Luke Street on 1/12/19.
+//
+
+/// Simplified version of work found here: https://github.com/pointfreeco/swift-overture/blob/master/Sources/Overture/ZipSequence.swift
+/// Zips 3 arrays together into a single array
+public func zip<A, B, C>(_ a: [A], _ b: [B], _ c: [C]) -> [(A, B, C)] {
+    return zip(zip(a, b), c).map { return ($0.0.0, $0.0.1, $0.1) }
+}
+
+/// Zips 4 arrays together into a single array
+public func zip<A, B, C, D>( _ a: [A], _ b: [B], _ c: [C], _ d: [D]) -> [(A, B, C, D)] {
+    return zip(zip(a, b, c), d).map { return ($0.0.0, $0.0.1, $0.0.2, $0.1) }
+}
+


### PR DESCRIPTION
Thanks for the awesome project! I am currently using this library for two different command line tools and its great! While working I wanted to add a little more type safety by using enums instead of String keys, so I wrote a small layer on top I thought it might benefit the rest of the community so here it is in a PR. 

Purely additive feature which allows more type safe commands using enums to model Arguments, Options, and Flags. Examples of usage can be found [here](https://github.com/ldstreet/PlayDocs/blob/master/Sources/PlayDocs/ConvertCommand.swift) and [here](https://github.com/ldstreet/PlayDocs/blob/master/Sources/PlayDocs/NewCommand.swift).

With this change Commands have the option of conforming to`CommandProtocol` (name up for bike shedding) which allows you to define 3 associated types. These types need to be `CaseIterable` and conform to the protocols `CommandArguments`, `CommandOptions`, and `CommandFlags`. After these types are defined and specified, the command will automatically partially conform to `Command` and simply needs to add the `help` and `run` requirements. Within `run`, you can now access your arguments, options, and flags via the enum like this:

```swift
let arg1 = try context.argument(Arguments.arg1)
let opt1 = context.option(Options.opt1)
let flag1 = context.flag(Flags.flag1
```

Example:
```swift
 struct CowsayCommand: CommandProtocol {

     enum Arguments: CommandArguments {
         case message
     }

     enum Options: CommandOptions {
         case eyes, tongue
     }

     enum Flags: CommandFlags {}

     var help: [String] {
         return ["Generates ASCII picture of a cow with a message."]
     }

     func run(using context: CommandContext) throws -> Future<Void> {
         let message = try context.argument(Arguments.message)
         let eyes = context.option(Options.eyes) ?? "oo"
         let tongue = context.option(Options.tongue) ?? " "
         let padding = String(repeating: "-", count: message.count)
         let text: String = """
           \(padding)
         < \(message) >
           \(padding)
                   \\   ^__^
                    \\  (\(eyes)\\_______
                       (__)\\       )\\/\\
                         \(tongue)  ||----w |
                            ||     ||
         """
         context.console.print(text)
         return .done(on: context.container)
     }
 }
```

Feedback welcome!