### PR TITLE
NIO 2 is released

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .library(name: "ConsoleKit", targets: ["ConsoleKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence"),
+        // 🚀
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [
         .target(name: "ConsoleKit", dependencies: ["NIO"]),

--- a/Sources/ConsoleKit/Command/Run/CommandInput.swift
+++ b/Sources/ConsoleKit/Command/Run/CommandInput.swift
@@ -65,7 +65,7 @@ public struct CommandInput {
                     arguments[i] = nil
                 } else {
                     // If we want extract a flag, it just needs to be anywhere in the option string to match.
-                    guard let index = arg.index(of: short) else {
+                    guard let index = arg.firstIndex(of: short) else {
                         continue
                     }
                     


### PR DESCRIPTION
Get rid of the `convergence` since we can use full-blown NIO2.

```
Test Suite 'All tests' passed at 2019-04-02 16:40:00.996.
	 Executed 19 tests, with 0 failures (0 unexpected) in 8.839 (8.840) seconds
```