### PR TITLE
typesafe improvements

### DIFF
--- a/Sources/ConsoleKit/Command/Base/CommandRunnable.swift
+++ b/Sources/ConsoleKit/Command/Base/CommandRunnable.swift
@@ -1,7 +1,7 @@
 /// A type-erased `CommandRunnable`.
 public protocol AnyCommandRunnable {
     /// An instance of the type that represents the command's valid inputs/signature.
-    static var anySignature: CommandSignature { get }
+    var anySignature: CommandSignature { get }
     
     /// Text that will be displayed when `--help` is passed.
     var help: String? { get }
@@ -26,7 +26,7 @@ public protocol CommandRunnable: AnyCommandRunnable {
     /// An instance of the type that represents the command's valid signature.
     ///
     /// The type-specific implementation of `AnyCommandRunnable.inputs`.
-    static var signature: Signature { get }
+    var signature: Signature { get }
     
     /// Runs the command against the supplied input.
     func run(using context: CommandContext<Self>) throws
@@ -36,7 +36,7 @@ extension CommandRunnable {
     /// The default implementation of `AnyCommandRunnable.inputs`.
     ///
     /// - Returns: The `CommandRunnable.signature` value.
-    public static var anySignature: CommandSignature {
+    public var anySignature: CommandSignature {
         return self.signature
     }
     
@@ -47,7 +47,7 @@ extension CommandRunnable {
     ///
     /// - Throws: `ConsoleError.invalidSignature` is the context type-cast fails.
     public func run(using anyContext: AnyCommandContext) throws {
-        let context = anyContext.context(command: Self.self)
+        let context = anyContext.context(command: self)
         return try self.run(using: context)
     }
 }

--- a/Sources/ConsoleKit/Command/Base/Option.swift
+++ b/Sources/ConsoleKit/Command/Base/Option.swift
@@ -13,7 +13,7 @@ public protocol AnyOption {
     var optionType: OptionType { get }
     
     /// The type that the option value gets decoded to.
-    var type: LosslessStringConvertible.Type { get }
+    var valueType: LosslessStringConvertible.Type { get }
 }
 
 /// A supported option for a command.
@@ -44,27 +44,8 @@ public struct Option<Value>: AnyOption where Value: LosslessStringConvertible {
     /// The type that the option value gets decoded to.
     ///
     /// Required by `AnyOption`.
-    public var type: LosslessStringConvertible.Type {
+    public var valueType: LosslessStringConvertible.Type {
         return Value.self
-    }
-    
-    /// Creates a new `Option` with the `optionType` set to `.flag`.
-    ///
-    ///     let verbose = Option<Bool>(name: "verbose", short: "v", help: "Output debug logs")
-    ///
-    /// - Parameters:
-    ///   - name: The option's unique name. Use this to get the option value from the `CommandContext`.
-    ///   - short: The short-hand for the flag that can be passed in to the command call.
-    ///   - help: The option's help text when `--help` is passed in.
-    public init(
-        name: String,
-        short: Character? = nil,
-        help: String? = nil
-    ) {
-        self.name = name
-        self.short = short
-        self.help = help
-        self.optionType = .flag
     }
     
     /// Creates a new `Option` with the `optionType` set to `.value`.
@@ -79,22 +60,31 @@ public struct Option<Value>: AnyOption where Value: LosslessStringConvertible {
     public init(
         name: String,
         short: Character? = nil,
-        default: Value?,
+        type: OptionType,
         help: String? = nil
     ) {
         self.name = name
         self.short = short
         self.help = help
-        self.optionType = .value(default: `default`?.description)
+        self.optionType = type
     }
 }
 
 public enum OptionType {
+    /// Normal option. Requires a value.
+    ///
+    ///     --branch beta
+    ///
+    public static var value: OptionType {
+        return .value(default: nil)
+    }
+
     /// Normal option. Requires a value if supplied and there is no default.
     ///
     ///     --branch beta
     ///
     case value(default: String?)
+
     /// Flag option. Does not support a value. If supplied, the value is true.
     ///
     ///     --xcode

--- a/Sources/ConsoleKit/Command/Command/Command.swift
+++ b/Sources/ConsoleKit/Command/Command/Command.swift
@@ -4,7 +4,7 @@ public protocol AnyCommand: AnyCommandRunnable { }
 extension AnyCommand {
     /// See `AnyCommandRunnable`
     public var type: CommandRunnableType {
-        return .command(arguments: Self.anySignature.arguments)
+        return .command(arguments: self.anySignature.arguments)
     }
 }
 

--- a/Sources/ConsoleKit/Command/Group/BasicCommandGroup.swift
+++ b/Sources/ConsoleKit/Command/Group/BasicCommandGroup.swift
@@ -1,11 +1,10 @@
 /// A basic `CommandGroup` implementation.
 internal struct BasicCommandGroup: CommandGroup {
-    
     /// See `CommandRunnable`.
     struct Signature: CommandSignature { }
     
     /// See `CommandRunnable`.
-    static let signature: BasicCommandGroup.Signature = Signature()
+    let signature: BasicCommandGroup.Signature = Signature()
     
     /// See `CommandGroup`.
     var commands: Commands

--- a/Sources/ConsoleKit/Command/Run/Console+Run.swift
+++ b/Sources/ConsoleKit/Command/Run/Console+Run.swift
@@ -83,26 +83,26 @@ extension Console {
     }
 }
 
-extension AnyOption {
-    fileprivate static var no: Option<Bool> {
-        return .init(name: "no", short: "n", help: "Automatically answers 'no' to all confirmiations.")
+private extension AnyOption {
+    static var no: Option<Bool> {
+        return .init(name: "no", short: "n", type: .flag, help: "Automatically answers 'no' to all confirmiations.")
     }
     
-    fileprivate static var yes: Option<Bool> {
-        return .init(name: "yes", short: "y", help: "Automatically answers 'yes' to all confirmiations.")
+    static var yes: Option<Bool> {
+        return .init(name: "yes", short: "y", type: .flag, help: "Automatically answers 'yes' to all confirmiations.")
     }
     
-    fileprivate static var help: Option<Bool> {
-        return .init(name: "help", short: "h")
+    static var help: Option<Bool> {
+        return .init(name: "help", short: "h", type: .flag)
     }
     
-    fileprivate static var autocomplete: Option<Bool> {
-        return .init(name: "autocomplete")
+    static var autocomplete: Option<Bool> {
+        return .init(name: "autocomplete", type: .flag)
     }
 }
 
-extension AnyArgument {
-    fileprivate static var subcommand: Argument<String> {
+private extension AnyArgument {
+    static var subcommand: Argument<String> {
         return .init(name: "sucommand")
     }
 }

--- a/Sources/ConsoleKit/Command/Run/Console+Run.swift
+++ b/Sources/ConsoleKit/Command/Run/Console+Run.swift
@@ -12,11 +12,14 @@ extension Console {
     ///     - input: Mutable `CommandInput` to parse `CommandOption`s and `CommandArgument`s from.
     /// - returns: A `Future` that will complete when the command finishes.
     public func run(_ runnable: AnyCommandRunnable, input: inout CommandInput) throws {
+        // stores the latest command to run recursively so that we can
+        // print a useful help message in the error case
+        var current = runnable
         do {
-            return try _run(runnable, input: &input)
+            return try self._run(runnable, input: &input, current: &current)
         } catch {
             if error is CommandError {
-                outputHelp(for: runnable, executable: input.executablePath.joined(separator: " "))
+                self.outputHelp(for: current, executable: input.executablePath.joined(separator: " "))
             }
             throw error
         }
@@ -25,12 +28,12 @@ extension Console {
     /// Runs the command, throwing if no commands are available.
     ///
     /// See `Console.run(...)`.
-    private func _run(_ runnable: AnyCommandRunnable, input: inout CommandInput) throws {
+    private func _run(_ runnable: AnyCommandRunnable, input: inout CommandInput, current: inout AnyCommandRunnable) throws {
         // check -n and -y flags.
         if try input.parse(option: Option<Bool>.no) == "true" {
-            confirmOverride = false
+            self.confirmOverride = false
         } else if try input.parse(option: Option<Bool>.yes) == "true" {
-            confirmOverride = true
+            self.confirmOverride = true
         }
 
         // try to run subcommand first
@@ -46,7 +49,8 @@ extension Console {
                 // executable should include all subcommands
                 // to get to the desired command
                 input.executablePath.append(name)
-                try run(subcommand, input: &input)
+                current = subcommand
+                try self._run(subcommand, input: &input, current: &current)
                 return
             }
         case .command: break
@@ -54,10 +58,10 @@ extension Console {
 
         if let help = try input.parse(option: Option<Bool>.help) {
             assert(help == "true")
-            outputHelp(for: runnable, executable: input.executablePath.joined(separator: " "))
+            self.outputHelp(for: runnable, executable: input.executablePath.joined(separator: " "))
         } else if let autocomplete = try input.parse(option: Option<Bool>.autocomplete) {
             assert(autocomplete == "true")
-            try outputAutocomplete(for: runnable, executable: input.executablePath.joined(separator: " "))
+            try self.outputAutocomplete(for: runnable, executable: input.executablePath.joined(separator: " "))
         } else {
             // try to run the default command first
             switch runnable.type {
@@ -70,13 +74,15 @@ extension Console {
                         )
                     }
                     let exec = input.executablePath.joined()
-                    output("Running default command: ".consoleText(.info) + exec.consoleText() + " " + defaultCommand.consoleText(.warning))
-                    try run(subcommand, input: &input)
+                    self.output("Running default command: ".consoleText(.info) + exec.consoleText() + " " + defaultCommand.consoleText(.warning))
+                    current = subcommand
+                    try self._run(subcommand, input: &input, current: &current)
                     return
                 }
             case .command: break
             }
 
+            current = runnable
             let context = try AnyCommandContext.make(from: &input, console: self, for: runnable)
             return try runnable.run(using: context)
         }

--- a/Sources/ConsoleKit/Command/Run/Output+Autocomplete.swift
+++ b/Sources/ConsoleKit/Command/Run/Output+Autocomplete.swift
@@ -6,7 +6,7 @@ extension Console {
         case .command(let arguments): autocomplete += arguments.map { $0.name }
         case .group(let commands): autocomplete += commands.commands.keys
         }
-        autocomplete += type(of: runnable).anySignature.options.map { "--" + $0.name }
+        autocomplete += runnable.anySignature.options.map { "--" + $0.name }
         output(autocomplete.joined(separator: " "), style: .plain)
     }
 }

--- a/Sources/ConsoleKit/Command/Run/Output+Help.swift
+++ b/Sources/ConsoleKit/Command/Run/Output+Help.swift
@@ -2,7 +2,6 @@ extension Console {
     /// Outputs help for a `CommandRunnable`, this is called automatically when `--help` is
     /// passed or when input validation fails.
     internal func outputHelp(for runnable: AnyCommandRunnable, executable: String) {
-        let runnableType = type(of: runnable)
         output("Usage: ".consoleText(.info) + executable.consoleText() + " ", newLine: false)
 
         switch runnable.type {
@@ -14,7 +13,7 @@ extension Console {
             output("<command> ".consoleText(.warning), newLine: false)
         }
 
-        for opt in runnableType.anySignature.options {
+        for opt in runnable.anySignature.options {
             if let short = opt.short {
                 output("[--\(opt.name),-\(short)] ".consoleText(.success), newLine: false)
             } else {
@@ -28,7 +27,7 @@ extension Console {
             print(help)
         }
 
-        var names = runnableType.anySignature.options.map { $0.name }
+        var names = runnable.anySignature.options.map { $0.name }
 
         switch runnable.type {
         case .command(let arguments):
@@ -40,10 +39,10 @@ extension Console {
         let padding = names.longestCount + 2
 
         if runnable is AnyCommand {
-            if runnableType.anySignature.arguments.count > 0 {
+            if runnable.anySignature.arguments.count > 0 {
                 print()
                 output("Arguments:".consoleText(.info))
-                for arg in runnableType.anySignature.arguments {
+                for arg in runnable.anySignature.arguments {
                     outputHelpListItem(
                         name: arg.name,
                         help: arg.help,
@@ -84,10 +83,10 @@ extension Console {
             }
         }
 
-        if runnableType.anySignature.options.count > 0 {
+        if runnable.anySignature.options.count > 0 {
             print()
             output("Options:".consoleText(.info))
-            for opt in runnableType.anySignature.options {
+            for opt in runnable.anySignature.options {
                 outputHelpListItem(
                     name: opt.name,
                     help: opt.help,

--- a/Tests/ConsoleKitTests/CommandTests.swift
+++ b/Tests/ConsoleKitTests/CommandTests.swift
@@ -47,8 +47,8 @@ class CommandTests: XCTestCase {
 
     func testShortFlagNeedsToMatchExactly() throws {
         var input = CommandInput(arguments: ["vapor", "sub", "test", "-x", "exact", "-y_not_exact", "not_exact"])
-        XCTAssertEqual(try input.parse(option: Option<String>(name: "xShort", short: "x", default: nil)), "exact")
-        XCTAssertNil(try input.parse(option: Option<String>(name: "yShort", short: "y", default: nil)))
+        XCTAssertEqual(try input.parse(option: Option<String>(name: "xShort", short: "x", type: .value)), "exact")
+        XCTAssertNil(try input.parse(option: Option<String>(name: "yShort", short: "y", type: .value)))
     }
 
     func testDeprecatedFlag() throws {

--- a/Tests/ConsoleKitTests/Utilities.swift
+++ b/Tests/ConsoleKitTests/Utilities.swift
@@ -4,10 +4,10 @@ extension String: Error {}
 
 final class TestGroup: CommandGroup {
     struct Signature: CommandSignature {
-        let version = Option<Bool>(name: "version", help: "Prints the version")
+        let version = Option<Bool>(name: "version", type: .flag, help: "Prints the version")
     }
     
-    static let signature: TestGroup.Signature = Signature()
+    let signature: TestGroup.Signature = Signature()
     
     let commands: Commands = [
         "test": TestCommand(),
@@ -25,10 +25,10 @@ final class TestGroup: CommandGroup {
 
 final class SubGroup: CommandGroup {
     struct Signature: CommandSignature {
-        let version = Option<Bool>(name: "version", help: "Prints the version")
+        let version = Option<Bool>(name: "version", type: .flag, help: "Prints the version")
     }
     
-    static let signature: SubGroup.Signature = Signature()
+    let signature: SubGroup.Signature = Signature()
     
     let commands: Commands = [
         "test": TestCommand()
@@ -50,13 +50,13 @@ final class TestCommand: Command {
         An error will occur if none exists
         """)
         
-        let bar = Option<String>(name: "bar", short: "b", default: nil, help: """
+        let bar = Option<String>(name: "bar", short: "b", type: .value, help: """
         Add a bar if you so desire
         Try passing it
         """)
     }
 
-    static let signature: TestCommand.Signature = Signature()
+    let signature: TestCommand.Signature = Signature()
     
     let help: String? = "This is a test command"
 


### PR DESCRIPTION
This PR does a couple of small things to improve usability of ConsoleKit after the type safe updates:

1: In usage, it's a little weird that `help` is a member var but `signature` is static. They are related, so they should both have the same scope. I think instance makes the most sense since it's what Console 3.0 does and it gives the user more freedom.

2: In usage, using `Option(..., default: nil)` to get a value type option was not clear. I think the `OptionType` should be a required parameter since it was required in Console 3.0 (Option.value and Option.flag). I added a convenience `.value` where default = nil to make it easier to use.

3. There was a bug causing too many help outputs to be printed. I've added some code to ensure that only the last attempted runnable to run has its help printed. 